### PR TITLE
fix tls errors

### DIFF
--- a/pytak/__init__.py
+++ b/pytak/__init__.py
@@ -44,6 +44,7 @@ from .constants import (
     DEFAULT_TLS_PARAMS_OPT,
     DEFAULT_TLS_PARAMS_REQ,
     DEFAULT_HOST_ID,
+    BOOLEAN_TRUTH
 )
 
 from .classes import (

--- a/pytak/constants.py
+++ b/pytak/constants.py
@@ -72,3 +72,11 @@ DEFAULT_TLS_PARAMS_OPT: list = [
     "PYTAK_TLS_DONT_CHECK_HOSTNAME",
     "PYTAK_TLS_DONT_VERIFY"
 ]
+
+BOOLEAN_TRUTH: list = [
+    "true",
+    "yes",
+    "y",
+    "on",
+    "1"
+]


### PR DESCRIPTION
Ironed out TLS with your v5 stuff.  
`get_tls_config()` wasn't passing the config
and reordered the *don't checks* to prevent error setting `ssl_ctx.verify_mode = ssl.CERT_NONE` while `ssl_ctx.check_hostname` was still true.
