### PR TITLE
implement rxworker

### DIFF
--- a/pytak/__init__.py
+++ b/pytak/__init__.py
@@ -42,7 +42,6 @@ from .constants import (  # NOQA
     DEFAULT_TLS_PARAMS_OPT,
     DEFAULT_TLS_PARAMS_REQ,
     DEFAULT_HOST_ID,
-    BOOLEAN_TRUTH,
 )
 
 from .classes import (  # NOQA

--- a/pytak/asyncio_dgram/aio.py
+++ b/pytak/asyncio_dgram/aio.py
@@ -2,6 +2,7 @@ import asyncio
 import pathlib
 import socket
 import warnings
+import sys
 
 # Python 3.6 support:
 if sys.version_info[:2] >= (3, 7):

--- a/pytak/asyncio_dgram/aio.py
+++ b/pytak/asyncio_dgram/aio.py
@@ -3,6 +3,12 @@ import pathlib
 import socket
 import warnings
 
+# Python 3.6 support:
+if sys.version_info[:2] >= (3, 7):
+    from asyncio import get_running_loop
+else:
+    from asyncio import get_event_loop as get_running_loop
+
 __all__ = ("TransportClosed", "bind", "connect", "from_socket", "DatagramClient")
 
 
@@ -221,7 +227,7 @@ async def bind(addr):
                   abstract sockets).
     @return     - A DatagramServer instance
     """
-    loop = asyncio.get_event_loop()
+    loop = get_running_loop()
     recvq = asyncio.Queue()
     excq = asyncio.Queue()
     drained = asyncio.Event()
@@ -254,7 +260,7 @@ async def connect(addr):
                   for abstract sockets).
     @return     - A DatagramClient instance
     """
-    loop = asyncio.get_event_loop()
+    loop = get_running_loop()
     recvq = asyncio.Queue()
     excq = asyncio.Queue()
     drained = asyncio.Event()
@@ -287,7 +293,7 @@ async def from_socket(sock):
     @return     - A DatagramClient for connected sockets, otherwise a
                   DatagramServer.
     """
-    loop = asyncio.get_event_loop()
+    loop = get_running_loop()
     recvq = asyncio.Queue()
     excq = asyncio.Queue()
     drained = asyncio.Event()

--- a/pytak/classes.py
+++ b/pytak/classes.py
@@ -22,7 +22,7 @@ import asyncio
 import logging
 import random
 
-from configparser import SectionProxy
+from configparser import ConfigParser, SectionProxy
 
 import pytak
 

--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -147,7 +147,7 @@ async def protocol_factory(  # pylint: disable=too-many-locals,too-many-branches
         reader, writer = await asyncio.open_connection(host, port)
     elif scheme in ["tls", "ssl"]:
         host, port = pytak.parse_url(cot_url)
-        tls_config: ConfigParser = get_tls_config(config)
+        tls_config: SectionProxy = get_tls_config(config)
 
         client_cert = tls_config.get("PYTAK_TLS_CLIENT_CERT")
         client_key = tls_config.get("PYTAK_TLS_CLIENT_KEY")
@@ -224,8 +224,8 @@ async def txworker_factory(
     Creates a PyTAK TXWorker based on URL parameters.
 
     :param cot_url: URL to COT Destination.
-    :param event_queue: asyncio.Queue worker to get events from.
-    :return: EventWorker or asyncio Protocol
+    :param queue: asyncio.Queue worker to get events from.
+    :return: TXWorker or asyncio Protocol
     """
     _, writer = await protocol_factory(config)
     return pytak.TXWorker(queue, config, writer)
@@ -235,11 +235,11 @@ async def rxworker_factory(
     queue: asyncio.Queue, config: SectionProxy
 ) -> pytak.RXWorker:
     """
-    Creates a PyTAK TXWorker based on URL parameters.
+    Creates a PyTAK RXWorker based on URL parameters.
 
-    :param cot_url: URL to COT Destination.
-    :param event_queue: asyncio.Queue worker to get events from.
-    :return: EventWorker or asyncio Protocol
+    :param cot_url: URL of COT Source.
+    :param queue: asyncio.Queue worker to put received events.
+    :return: RXWorker or asyncio Protocol
     """
     reader, _ = await protocol_factory(config)
     return pytak.RXWorker(queue, config, reader)

--- a/pytak/constants.py
+++ b/pytak/constants.py
@@ -72,5 +72,3 @@ DEFAULT_TLS_PARAMS_OPT: list = [
     "PYTAK_TLS_DONT_CHECK_HOSTNAME",
     "PYTAK_TLS_DONT_VERIFY",
 ]
-
-BOOLEAN_TRUTH: list = ["true", "yes", "y", "on", "1"]

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -105,7 +105,7 @@ async def test_eventworker():
     transport.is_closing = mock.Mock()
     protocol._drain_helper = make_mocked_coro()
 
-    loop = asyncio.get_running_loop()
+    loop = get_running_loop()
     writer = asyncio.StreamWriter(transport, protocol, None, loop)
 
     worker: pytak.Worker = pytak.TXWorker(event_queue, {}, writer)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -28,12 +28,18 @@ Some methods borrowed from https://github.com/aio-libs/aiohttp"""
 import asyncio
 import enum
 import inspect
-
+import sys
 from unittest import mock
 
 import pytest
 
 import pytak
+
+# Python 3.6 support:
+if sys.version_info[:2] >= (3, 7):
+    from asyncio import get_running_loop
+else:
+    from asyncio import get_event_loop as get_running_loop
 
 
 __author__ = "Greg Albrecht W2GMD <oss@undef.net>"
@@ -99,7 +105,7 @@ async def test_eventworker():
     transport.is_closing = mock.Mock()
     protocol._drain_helper = make_mocked_coro()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     writer = asyncio.StreamWriter(transport, protocol, None, loop)
 
     worker: pytak.Worker = pytak.TXWorker(event_queue, {}, writer)


### PR DESCRIPTION
Not sure you'll be interested in this.  

The second commit is consistency cleanup for comments and types.

The first commit provides an implementation of RXWorker that enqueues cot messages that are read from the protocol.  My assumption may be wrong...that `</event>` is a standard delimiter for CoT messages.  Anyway, that leaves the consumer to just provide a queueworker to process the rx_queue.

For background, I'm proxying CoT messages between SOURCE and TAK:
- SOURCEWorker (QueueWorker) receives from SOURCE and puts to `tx_queue`
- TXWorker pops from `tx_queue` and writes to TAK
- RXWorker reads from TAK and puts to `rx_queue`
- TAKWorker pops from `rx_queue` and sends to SOURCE

The existing pytak classes kind of suggest consolidating the last two by extending RXWorker and using the reader directly.  That makes sense if the reader  is getting arbitrary data, but if we can assume we are reading cot xml, then the base code can just fill the rx_queue.  But again, maybe my assumption is wrong.  But if not, I like the idea of a consumer just providing a url, and then handling the queues.
